### PR TITLE
Don't close single quotes when inside a word

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -110,7 +110,10 @@ function! AutoPairsInsert(key)
     return "\<Right>"
   end
 
-  return open.close."\<Left>"
+  if a:key == "'" && prev_char =~ '\v\w'
+    return a:key
+  else
+    return open.close."\<Left>"
 endfunction
 
 function! AutoPairsDelete()


### PR DESCRIPTION
This is a simple change that allows you to type words with single quotes (John's, you're, 1980's, etc.) without the quotes becoming closed.
