### PR TITLE
add option to skip inserting a pair when directly before a word character

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Default Options:
 
     let g:AutoPairsFlyMode = 0
     let g:AutoPairsShortcutBackInsert = '<M-b>'
+    let g:AutoPairsSkipBeforeWord = 0
 
 Shortcuts
 ---------
@@ -213,6 +214,12 @@ Options
         Default : <M-b>
 
         Work with FlyMode, insert the key at the Fly Mode jumped postion
+
+*   g:AutoPairsSkipBeforeWord
+
+        Default : 0
+
+        Set to 1 : While not in FlyMode, skip inserting a pair when directly before a word-character.
 
 TroubleShooting
 ---------------

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -50,6 +50,11 @@ if !exists('g:AutoPairsShortcutJump')
   let g:AutoPairsShortcutJump = '<M-n>'
 endif
 
+" Skip auto-pairing if the cursor is directly before a word-character
+if !exists('g:AutoPairsSkipBeforeWord')
+  let g:AutoPairsSkipBeforeWord = 0
+end
+
 " Fly mode will for closed pair to jump to closed pair instead of insert.
 " also support AutoPairsBackInsert to insert pairs where jumped.
 if !exists('g:AutoPairsFlyMode')
@@ -88,6 +93,11 @@ function! AutoPairsInsert(key)
   if prev_char == '\'
     return a:key
   end
+
+  " Ignore auto open if next charater is a word-character (optional)
+  if !g:AutoPairsFlyMode && g:AutoPairsSkipBeforeWord == 1 && next_char =~ '\v\w'
+    return a:key
+  endif
 
   " The key is difference open-pair, then it means only for ) ] } by default
   if !has_key(g:AutoPairs, a:key)


### PR DESCRIPTION
Hi,

I added an option to skip the functionality when the cursor is places before a word-character.

I use this all the time when coming back to insert eg. brakets around already existing code.

Thanks for your work and this easy to understand codebase :)

Frank
