### PR TITLE
updated triple quote action

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -142,7 +142,7 @@ function! AutoPairsInsert(key)
     let pprev_char = line[col('.')-3]
     if pprev_char == open && prev_char == open
       " Double pair found
-      return a:key
+      return a:key."\<CR>".repeat(a:key,3)."\<Up>\<ESC>o"
     end
   end
 


### PR DESCRIPTION
this update works nicely when coding in python, not sure how other
languages will be impacted... 

changed the action on triple quote to add a closing quote and
start editing on the newly opened line inside the quotes.  

the only way to jump beyond the quotes is to escape and scroll down.
this is because a <CR> should give a new line, not jump to closing
quotes.
