### PR TITLE
Try to use space mapping without breaking abbreviations

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -419,7 +419,12 @@ function! AutoPairsInit()
   end
 
   if g:AutoPairsMapSpace
-    execute 'inoremap <buffer> <silent> <SPACE> <C-R>=AutoPairsSpace()<CR>'
+    " Try to respect abbreviations on a <SPACE>
+    let do_abbrev = ""
+    if v:version >= 703 && has("patch489")
+      let do_abbrev = "<C-]>"
+    endif
+    execute 'inoremap <buffer> <silent> <SPACE> '.do_abbrev.'<C-R>=AutoPairsSpace()<CR>'
   end
 
   if g:AutoPairsShortcutFastWrap != ''


### PR DESCRIPTION
Only works with vim 7.3 at patch 489 (from November 2012) since that allowed the use of C-] in mappings. Hopefully shouldn't break anything, since it only applies if vim is new enough and if it can trigger an abbreviation
