### PR TITLE
Fix for AutoPairsJump bug and an extra option

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -355,7 +355,7 @@ function! AutoPairsReturn()
       " Use \<BS> instead of \<ESC>cl will cause the placeholder deleted
       " incorrect. because <C-O>zz won't leave Normal mode.
       " Use \<DEL> is a bit wierd. the character before cursor need to be deleted.
-      let cmd = " \<C-O>zz\<ESC>cl"
+      let cmd = " \<C-O>zz\<ESC>cl\<ESC>"
     end
 
     " If equalprg has been set, then avoid call =

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -13,11 +13,11 @@ end
 let g:AutoPairsLoaded = 1
 
 if !exists('g:AutoPairs')
-  let g:AutoPairs = {'(':')', '[':']', '{':'}',"'":"'",'"':'"', '`':'`'}
+  let g:AutoPairs = {'(':')', '[':']', '{':'}','<':'>',"'":"'",'"':'"', '`':'`'}
 end
 
 if !exists('g:AutoPairsParens')
-  let g:AutoPairsParens = {'(':')', '[':']', '{':'}'}
+  let g:AutoPairsParens = {'(':')', '[':']', '{':'}', '<':'>'}
 end
 
 if !exists('g:AutoPairsMapBS')
@@ -254,7 +254,7 @@ function! AutoPairsDelete()
 endfunction
 
 function! AutoPairsJump()
-  call search('["\]'')}]','W')
+  call search('["\]'')}>]','W')
 endfunction
 " string_chunk cannot use standalone
 let s:string_chunk = '\v%(\\\_.|[^\1]|[\r\n]){-}'

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -24,6 +24,10 @@ if !exists('g:AutoPairsMapBS')
   let g:AutoPairsMapBS = 1
 end
 
+if !exists('g:AutoPairsNormalJump')
+  let g:AutoPairsNormalJump = 1
+end
+
 if !exists('g:AutoPairsMapCR')
   let g:AutoPairsMapCR = 1
 end
@@ -443,7 +447,10 @@ function! AutoPairsInit()
 
   if g:AutoPairsShortcutJump != ''
     execute 'inoremap <buffer> <silent> ' . g:AutoPairsShortcutJump. ' <ESC>:call AutoPairsJump()<CR>a'
-    execute 'noremap <buffer> <silent> ' . g:AutoPairsShortcutJump. ' :call AutoPairsJump()<CR>'
+
+    if g:AutoPairsNormalJump == 1
+        execute 'noremap <buffer> <silent> ' . g:AutoPairsShortcutJump. ' :call AutoPairsJump()<CR>'
+    end
   end
 
 endfunction

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -13,11 +13,11 @@ end
 let g:AutoPairsLoaded = 1
 
 if !exists('g:AutoPairs')
-  let g:AutoPairs = {'(':')', '[':']', '{':'}','<':'>',"'":"'",'"':'"', '`':'`'}
+  let g:AutoPairs = {'(':')', '[':']', '{':'}',"'":"'",'"':'"', '`':'`'}
 end
 
 if !exists('g:AutoPairsParens')
-  let g:AutoPairsParens = {'(':')', '[':']', '{':'}', '<':'>'}
+  let g:AutoPairsParens = {'(':')', '[':']', '{':'}'}
 end
 
 if !exists('g:AutoPairsMapBS')
@@ -258,7 +258,7 @@ function! AutoPairsDelete()
 endfunction
 
 function! AutoPairsJump()
-  call search('["\]'')}>]','W')
+  call search('["\]'')}]','W')
 endfunction
 " string_chunk cannot use standalone
 let s:string_chunk = '\v%(\\\_.|[^\1]|[\r\n]){-}'


### PR DESCRIPTION
Fixes issue #83

Also introduces a new option g:AutoPairsNormalJump that allows for the option of only doing a inoremap of g:AutoPairsShortcutJump.

For example, if I set g:AutoPairsShortcutJump to <c-f>, I can set g:AutoPairsNormalJump to 0 so that <c-f> is only mapped for jumping in insert mode. This will still allow <c-f> to be used for scrolling in normal mode.
