### PR TITLE
(Optional) don't auto close if there's text under cursor

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -20,6 +20,10 @@ if !exists('g:AutoPairsParens')
   let g:AutoPairsParens = {'(':')', '[':']', '{':'}'}
 end
 
+if !exists('g:AutoPairsDisableInsideText')
+  let g:AutoPairsDisableInsideText = 1
+endif
+
 if !exists('g:AutoPairsMapBS')
   let g:AutoPairsMapBS = 1
 end
@@ -72,6 +76,13 @@ function! AutoPairsInsert(key)
   if !b:autopairs_enabled
     return a:key
   end
+
+  if g:AutoPairsDisableInsideText == 1
+    let l:current_char = getline(".")[col(".")-1]
+    if strlen(l:current_char) != 0
+      return a:key
+    endif
+  endif
 
   let line = getline('.')
   let pos = col('.') - 1


### PR DESCRIPTION
Usually if there's text under the cursor closing paren will be in the wrong place (it should be after the text). Consider the following:
print "hello world" => print("hello world")

Using Auto Pairs current flow goes something like that (at least for me):
print "hello world" => print() "hello world" => and then I need to delete closing paren and rewrite it in the end

This patch adds a g:AutoPairsDisableInsideText which, when turned on, prevents adding closing pair when not writing new text
