### PR TITLE
option to only search current line for closing pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ Options
         set it to 1 to enable FlyMode.
         see FlyMode section for details.
 
+*   g:AutoPairsMultilineClose
+
+        Default : 1
+
+        When you press the key for the closing pair (e.g. `)`) it jumps past it.
+        If set to 1, then it'll jump to the next line, if there is only whitespace.
+        If set to 0, then it'll only jump to a closing pair on the same line.
+
 *   g:AutoPairsShortcutBackInsert
 
         Default : <M-b>

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -54,6 +54,12 @@ if !exists('g:AutoPairsFlyMode')
   let g:AutoPairsFlyMode = 0
 endif
 
+" When skipping the closed pair, look at the current and
+" next line as well.
+if !exists('g:AutoPairsMultilineClose')
+  let g:AutoPairsMultilineClose = 1
+endif
+
 " Work with Fly Mode, insert pair where jumped
 if !exists('g:AutoPairsShortcutBackInsert')
   let g:AutoPairsShortcutBackInsert = '<M-b>'
@@ -110,9 +116,13 @@ function! AutoPairsInsert(key)
 
       " Skip the character if closed pair is next character
       if current_char == ''
-        let next_lineno = line('.')+1
-        let next_line = getline(nextnonblank(next_lineno))
-        let next_char = matchstr(next_line, '\s*\zs.')
+        if g:AutoPairsMultilineClose
+          let next_lineno = line('.')+1
+          let next_line = getline(nextnonblank(next_lineno))
+          let next_char = matchstr(next_line, '\s*\zs.')
+        else
+          let next_char = matchstr(line, '\s*\zs.')
+        end
         if next_char == a:key
           return "\<ESC>e^a"
         endif


### PR DESCRIPTION
This adds the `g:AutoPairsMultilineClose` option.

    Default : 1

    When you press the key for the closing pair (e.g. `)`) it jumps past it.
    If set to 1, then it'll jump to the next line, if there is only whitespace.
    If set to 0, then it'll only jump to a closing pair on the same line.