### PR TITLE
Disable jump to closing bracket functionality by default

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -48,6 +48,10 @@ if !exists('g:AutoPairsShortcutJump')
   let g:AutoPairsShortcutJump = '<M-n>'
 endif
 
+if !exists('g:AutoPairsAnnoyingMode')
+  let g:AutoPairsAnnoyingMode = '0'
+endif
+
 " Fly mode will for closed pair to jump to closed pair instead of insert.
 " also support AutoPairsBackInsert to insert pairs where jumped.
 if !exists('g:AutoPairsFlyMode')

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -114,7 +114,11 @@ function! AutoPairsInsert(key)
         let next_line = getline(nextnonblank(next_lineno))
         let next_char = matchstr(next_line, '\s*\zs.')
         if next_char == a:key
-          return "\<ESC>e^a"
+          if g:AutoPairsAnnoyingMode
+            return "\<ESC>e^a"
+          else
+            return a:key
+          end
         endif
       endif
     endif
@@ -525,3 +529,4 @@ imap <script> <Plug>AutoPairsReturn <SID>AutoPairsReturn
 
 
 au BufEnter * :call AutoPairsTryInit()
+


### PR DESCRIPTION
I am inserting a closing bracket much more frequently than jumping to next closing bracket. The default functionality of this plugin was incredibly annoying to me, so I had to implement an option to make it configurable. Please feel free to rename the option if you don't consider the name appropriate. 