### PR TITLE
Make it possible to insert an indented line between html tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,15 @@ Options
 
         Default: {'(':')', '[':']', '{':'}',"'":"'",'"':'"', '`':'`'}
 
-*   b:AutoPairs
+*   g:AutoPairsNewline
 
-        Default: g:AutoPairs
+        Default: Same as g:AutoPairs, but with '>' and '<' added for indenting html tags.
+
+        The characters for inserting a new indented line after Return.
+
+*   b:AutoPairs, b:AutoPairsNewline
+
+        Default: g:AutoPairs, g:AutoPairsNewline
 
         Buffer level pairs set.
 

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -16,6 +16,11 @@ if !exists('g:AutoPairs')
   let g:AutoPairs = {'(':')', '[':']', '{':'}',"'":"'",'"':'"', '`':'`'}
 end
 
+if !exists('g:AutoPairsNewline')
+  let g:AutoPairsNewline = deepcopy(g:AutoPairs)
+  let g:AutoPairsNewline['>'] = '<'
+end
+
 if !exists('g:AutoPairsParens')
   let g:AutoPairsParens = {'(':')', '[':']', '{':'}'}
 end
@@ -378,7 +383,7 @@ function! AutoPairsReturn()
   let prev_char = pline[strlen(pline)-1]
   let cmd = ''
   let cur_char = line[col('.')-1]
-  if has_key(b:AutoPairs, prev_char) && b:AutoPairs[prev_char] == cur_char
+  if has_key(b:AutoPairsNewline, prev_char) && b:AutoPairsNewline[prev_char] == cur_char
     if g:AutoPairsCenterLine && winline() * 3 >= winheight(0) * 2
       " Use \<BS> instead of \<ESC>cl will cause the placeholder deleted
       " incorrect. because <C-O>zz won't leave Normal mode.
@@ -432,6 +437,10 @@ function! AutoPairsInit()
 
   if !exists('b:AutoPairs')
     let b:AutoPairs = g:AutoPairs
+  end
+
+  if !exists('b:AutoPairsNewline')
+    let b:AutoPairsNewline = g:AutoPairsNewline
   end
 
   " buffer level map pairs keys


### PR DESCRIPTION
Auto-Pairs makes it really easy to auto indent html tags on inserting a newline, so I added that functionality.

I added a variable to configure the characters where auto-pairs should insert a new indented line.

This variable is the same as g:AutoPairs, but I added `'>':'<'` to it by default. This makes auto-pairs insert a new indented line between a html tag. Example:

``` html
input:  <div>|</div> (press <CR> at |)
output: <div>
            |
        </div>
```
