### PR TITLE
Added variable to define AutoPairsCRKey

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -33,6 +33,10 @@ if !exists('g:AutoPairsMapCR')
   let g:AutoPairsMapCR = 1
 end
 
+if !exits('g:AutoPairsCRKey')
+  let g:AutoPairsCRKey = '<CR>'
+end
+
 if !exists('g:AutoPairsMapSpace')
   let g:AutoPairsMapSpace = 1
 end
@@ -548,7 +552,7 @@ function! AutoPairsTryInit()
         let old_cr = wrapper_name
       end
       " Always silent mapping
-      execute 'inoremap <script> <buffer> <silent> <CR> '.old_cr.'<SID>AutoPairsReturn'
+      execute 'inoremap <script> <buffer> <silent> ' .g:AutoPairsCRKey. ' ' .old_cr.'<SID>AutoPairsReturn'
     end
   endif
   call AutoPairsInit()


### PR DESCRIPTION
AutoPairs CR Remapping is not working together with deoplete.
int func() {|} on hitting CR is expandend to
int func() {
}

With this patch you can redefine the AutoPairsCRKey by using:
let g:AutoPairsCRKey = <S-CR>

The default behavious of using CR is kept.