### PR TITLE
Allow for only flying on current line

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Options
         When you press the key for the closing pair (e.g. `)`) it jumps past it.
         If set to 1, then it'll jump to the next line, if there is only whitespace.
         If set to 0, then it'll only jump to a closing pair on the same line.
+        If set to 0 with Fly Mode enabled, then it'll only fly on the current line.
 
 *   g:AutoPairsShortcutBackInsert
 

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -152,7 +152,13 @@ function! AutoPairsInsert(key)
       if n != -1
         return repeat(s:Right, n+1)
       end
-      if search(a:key, 'W')
+      " Only fly on current line if AutoPairsMultilineClose is set to 0
+      if g:AutoPairsMultilineClose
+        let stopline = 0
+      else
+        let stopline = line('.')
+      endif
+      if search(a:key, 'W', stopline)
         " force break the '.' when jump to different line
         return "\<Right>"
       endif


### PR DESCRIPTION
With Fly Mode enabled, only fly on current line if AutoPairsMultilineClose is set to 0
