### PR TITLE
Fix double-escape being needed

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -383,7 +383,9 @@ function! AutoPairsReturn()
       " Use \<BS> instead of \<ESC>cl will cause the placeholder deleted
       " incorrect. because <C-O>zz won't leave Normal mode.
       " Use \<DEL> is a bit wierd. the character before cursor need to be deleted.
-      let cmd = " \<C-O>zz\<ESC>cl"
+      " Adding a space, recentering, and deleting it interferes with default
+      " whitespace-removing behavior when exiting insert mode.
+      let cmd = "\<ESC>zzcc"
     end
 
     " If equalprg has been set, then avoid call =


### PR DESCRIPTION
This addresses https://github.com/jiangmiao/auto-pairs/issues/137

**Setup:**
- Open file long enough to go offscren
- Position cursor on the last line of the window
- Type:
```
if (something) {<cursor>}
```
- Hit return. You get:
```
if (something) {
    <cursor>
}
```
- Hit escape to exit insert mode

**Before:**
You still end up in insert mode, despite having pressed Escape, and the whitespace in the line is not removed as it should be given vim's default behaviour.

**After:**
Normal mode is entered, and the whitespace is removed as expected.
