### PR TITLE
Fix overwriting copied text when recentering

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -380,27 +380,23 @@ function! AutoPairsReturn()
   let cur_char = line[col('.')-1]
   if has_key(b:AutoPairs, prev_char) && b:AutoPairs[prev_char] == cur_char
     if g:AutoPairsCenterLine && winline() * 3 >= winheight(0) * 2
-      " Use \<BS> instead of \<ESC>cl will cause the placeholder deleted
-      " incorrect. because <C-O>zz won't leave Normal mode.
-      " Use \<DEL> is a bit wierd. the character before cursor need to be deleted.
-      " Adding a space, recentering, and deleting it interferes with default
-      " whitespace-removing behavior when exiting insert mode.
-      let cmd = "\<ESC>zzcc"
+      " Recenter before adding new line to avoid replacing line content
+      let cmd = "zz"
     end
 
     " If equalprg has been set, then avoid call =
     " https://github.com/jiangmiao/auto-pairs/issues/24
     if &equalprg != ''
-      return "\<ESC>O".cmd
+      return "\<ESC>".cmd."O"
     endif
 
     " conflict with javascript and coffee
     " javascript   need   indent new line
     " coffeescript forbid indent new line
     if &filetype == 'coffeescript' || &filetype == 'coffee'
-      return "\<ESC>k==o".cmd
+      return "\<ESC>".cmd."k==o"
     else
-      return "\<ESC>=ko".cmd
+      return "\<ESC>".cmd."=ko"
     endif
   end
   return ''


### PR DESCRIPTION
In https://github.com/jiangmiao/auto-pairs/pull/147 I introduced a bug: When you are near the bottom of the screen, open a brace, and hit return, I used `cc` to indent the line after recentering. However, this copies the existing contents of the line (an empty line) into the register, overwriting whatever was copied previously. I have changed the order so that recentering with `zz` happens before inserting a new line, so that simply calling `o` afterwards works as expected and the register is not overwritten.

**Setup**
1. Type some text, e.g. `test` and yank the line with `yy`
2. Make enough newlines so that the cursor is on the last line of the screen
3. Type a `{` and hit return
4. Paste with `p`.

**Existing behaviour**
The pasted line is empty, because the previous copied line is overwritten

**Behaviour after fix**
A line with `test` is added
