### PR TITLE
Allow to carry the remainder of the line when breaking line inside brackets

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -404,9 +404,12 @@ function! AutoPairsReturn()
     endif
 
     if carry
-      let pline = strpart(pline, 0, strlen(pline) - 1)
+      " make sure we carry only if trimmed line contains anything other
+      " than cur_char
+      let c1 = substitute(line, '^\s*\(.\{-}\)\s*$', '\1', '') != cur_char
 
       " do not carry if we are in the middle of wrapping parens
+      let pline = strpart(pline, 0, strlen(pline) - 1)
       let r1 = substitute(pline, '[^(]', '', 'g')
       let r2 = substitute(pline, '[^)]', '', 'g')
       let s1 = substitute(pline, '[^\[]', '', 'g')
@@ -414,9 +417,6 @@ function! AutoPairsReturn()
       let q1 = substitute(pline, '[^{]', '', 'g')
       let q2 = substitute(pline, '[^}]', '', 'g')
 
-      " make sure we carry only if trimmed line contains anything other
-      " than cur_char
-      let c1 = substitute(line, '^\s*\(.\{-}\)\s*$', '\1', '') != cur_char
       let c2 = strlen(r1) == strlen(r2) && strlen(s1) == strlen(s2) && strlen(q1) == strlen(q2)
 
       let carry = c1 && c2
@@ -424,7 +424,7 @@ function! AutoPairsReturn()
 
     if carry
       " remove-copy everything after the cur_char
-      let ret .= "\<ESC>wD"
+      let ret .= "\<ESC>^lD"
     endif
 
     " If equalprg has been set, then avoid call =


### PR DESCRIPTION
Example:

    if (something) {|<CR>} break;

becomes

    if (something) {
        break;
    }

Limited to parens **only** created in the same "insert mode session" and when cursor is not inside unclosed parens. Activated with:

    let g:AutoPairsCarryOnReturn = 1

In action:
![example](https://cloud.githubusercontent.com/assets/3148267/25251851/af2b561c-2612-11e7-86a0-d4373ba6120d.gif)

