### PR TITLE
Added an option to disable skipping characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Options
         Map <M-(> <M-)> <M-[> <M-]> <M-{> <M-}> <M-"> <M-'> to
         move character under the cursor to the pair.
 
+*   g:AutoPairsSkipCharacter
+
+        Default : 1
+
+        set it to 0 to disable skipping characters
+
 Buffer Level Pairs Setting
 --------------------------
 

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -320,9 +320,12 @@ Set it to 1 to enable |autopairs-flymode|.
 
 Default: 1
 
-When you press the key for the closing pair (e.g. `)`) it jumps past it.
-If set to 1, then it'll jump to the next line, if there is only 'whitespace'.
-If set to 0, then it'll only jump to a closing pair on the same line.
+
+|g:AutoPairsSkipCharaters|                                                  int
+
+Default: 1
+
+Set it to 0 to disable skipping characters.
 
 ==============================================================================
 6. Troubleshooting                                 *autopairs-troubleshooting*


### PR DESCRIPTION
You can set g:AutoPairsSkipCharacter to 0 to disable skipping characters
if the next character is the same as the input

 input: {}
 output: {}}

Once you get used to the plugin, you never insert the closing braked except you intend to actually have one.