### PR TITLE
updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ copy plugin/auto-pairs.vim to ~/.vim/plugin
 
 or if you are using `pathogen`:
 
-```git clone git://github.com/jiangmiao/auto-pairs.git ~/.vim/bundle/auto-pairs```
+```git clone git://github.com/jiangmiao/auto-pairs.git ~/.vim/plugin/auto-pairs```
 
 Features
 --------


### PR DESCRIPTION
In the README the instructions on how to install have an error. The new path should be `~/.vim/bundle/auto-pairs` instead of `~/.vim/plugin/auto-pairs` in order for it to work.