### PR TITLE
Add option to use Parens Decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Features
         input: '|' (press <SPACE> at |)
         output: ' |'
 
+*   Insert Parens decorators for [], (), {}. Useful for templating languages such as [Jinja](http://jinja.pocoo.org/)/[Twig](twig.sensiolabs.org)/[Liquid](https://github.com/Shopify/liquid)
+
+        input: {|} (press % at |)
+        output {%|%}
+
+        input: {|} (press #<SPACE>foo at |)
+        output {# foo| #}
+
 *   Skip ' when inside a word
 
         input: foo| (press ' at |)
@@ -182,6 +190,30 @@ Options
         Default: g:AutoPairs
 
         Buffer level pairs set.
+
+*   g:AutoPairsEnableParensDecorators
+
+        Default: 0
+
+        Enables parens decorators, such as %, #, =.
+
+*   g:AutoPairsParens
+
+        Default: {'(':')', '[':']', '{':'}'}
+
+        Which pairs should be considered paren.
+
+*   g:AutoPairsParensDecorators
+
+        Default: {'%':'%', '#':'#', '=':'='}
+
+        Parens decorator value pairs.
+
+*   b:AutoPairsParensDecorators
+
+        Default: g:AutoPairsParensDecorators
+
+        Buffer level parens decorator set.
 
 *   g:AutoPairsShortcutToggle
 


### PR DESCRIPTION
Parens decorators are symbols that can be used inside parens and create
a custom compound open-close sequence.
It is useful for some templating languages such as [Jinja](http://jinja.pocoo.org/)/[Twig](twig.sensiolabs.org)/[Liquid](https://github.com/Shopify/liquid)
and must be opted in with a config option.

Closes #114 