### PR TITLE
Fix AutoPairsJump for custom pairs

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -290,7 +290,7 @@ function! AutoPairsDelete()
 endfunction
 
 function! AutoPairsJump()
-  call search('["\]'')}]','W')
+  call search('[' . escape(join(values(b:AutoPairs), ''), "']") . ']', 'W')
 endfunction
 " string_chunk cannot use standalone
 let s:string_chunk = '\v%(\\\_.|[^\1]|[\r\n]){-}'


### PR DESCRIPTION
By default AutoPairsJump function is hardcoded for default pairs only, so it doesn't work for custom pairs and misses '`' (which is in default AutoPairs).

This commit modifies AutoPairsJump function to properly work with custom defined pairs by using `b:AutoPairs` variable values, so that the function will attempt to search for any closing pair that is configured.