### PR TITLE
Fix breaking of keymap behavior

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -501,6 +501,20 @@ function! AutoPairsInit()
     execute 'noremap <buffer> <silent> ' . g:AutoPairsShortcutJump. ' :call AutoPairsJump()<CR>'
   end
 
+  if &keymap != ''
+    let l:imsearch = &imsearch
+    let l:iminsert = &iminsert
+    let l:imdisable = &imdisable
+    execute 'setlocal keymap=' . &keymap
+    execute 'setlocal imsearch=' . l:imsearch
+    execute 'setlocal iminsert=' . l:iminsert
+    if l:imdisable
+      execute 'setlocal imdisable'
+    else
+      execute 'setlocal noimdisable'
+    end
+  end
+
 endfunction
 
 function! s:ExpandMap(map)


### PR DESCRIPTION
With this workaround, the keymap is reset during the plugin init and works fine again.

The minimal config to check:
```vim
set keymap=russian-jcukenwin
set iminsert=0
set imsearch=0
```

Steps to reproduce:

1. check out the plugin
1. enter into the insert mode, change the layout with `ctrl+^`
1. press the keys: ```'`"[{```

#### Expected behavior
The output is `эёЭхХ`

#### Actual behavior
The output is ```'`"[{}]"`'```

This PR is fixing #93 