### PR TITLE
Equal pair detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Breaks '.' - [issue #3](https://github.com/jiangmiao/auto-pairs/issues/3)
 Contributors
 ------------
 * [camthompson](https://github.com/camthompson)
+* [kkoomen](https://github.com/kkoomen)
 
 
 License

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Features
 
         }|
 
-*   Auto detect when to close by checking the equality of pairs within the buffer
+*   Auto detect how to close/delete pairs by checking the equality of pairs
 
         input:
             const user = getUser|id)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Features
         ---
 
         input:
+            ((|)
+
+        (press <BS> at |)
+
+        output:
+            (|)
+
+        ---
+
+        input:
             |]]
 
         (press [ at |)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,13 @@ Options
         for pair {'begin': 'end//n]'}, e is not mapped, use wild closed pair ] to jump over 'end'
         use <M-b> to back insert ] after jumping
 
+*   g:AutoPairsEqualPairDetection
+
+        Default: 1
+
+        Detects when to close a pair by detecting the equality of pairs within
+        the current buffer. (This feature is not supported for multibyte pairs)
+
 Buffer Level Pairs Setting
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,35 @@ Features
 
         }|
 
+*   Auto detect when to close by checking the equality of pairs within the buffer: >
+
+        input:
+            const user = getUser|id)
+
+        (press ( at |)
+
+        output:
+            const user = getUser(id)
+
+        ---
+
+        input:
+            |]]
+
+        (press [ at |)
+
+        output:
+            [|]]
+
+        (press [ at | again)
+
+        output:
+            [[|]]
+
+        (press [ at | again)
+
+        output:
+            [[[|]]]
 *  Fly Mode
 
         input: if(a[3)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Features
 
         }|
 
-*   Auto detect when to close by checking the equality of pairs within the buffer: >
+*   Auto detect when to close by checking the equality of pairs within the buffer
 
         input:
             const user = getUser|id)
@@ -146,7 +146,7 @@ Features
         See Fly Mode section for details
 
 *  Multibyte Pairs
-        
+
         Support any multibyte pairs such as <!-- -->, <% %>, """ """
         See multibyte pairs section for details
 

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -103,6 +103,35 @@ Support ```, ''' and """: >
         output:
             '''|'''
 
+Auto detect when to close by checking the equality of pairs within the buffer: >
+        input:
+            const user = getUser|id)
+
+        (press ( at |)
+
+        output:
+            const user = getUser(id)
+
+        ---
+
+        input:
+            |]]
+
+        (press [ at |)
+
+        output:
+            [|]]
+
+        (press [ at | again)
+
+        output:
+            [[|]]
+
+        (press [ at | again)
+
+        output:
+            [[[|]]]
+
 Delete Repeated Pairs in one time: >
 
         input: """|""" (press <BS> at |)
@@ -245,6 +274,15 @@ Fast wrap the word. All pairs will be considered as a block (including <>).
 Default: <M-n>
 
 Jump to the next closed pair.
+
+
+                                                *g:AutoPairsEqualPairDetection*
+|g:AutoPairsEqualPairDetection|                                             int
+
+Default: 1
+
+Detects when to close a pair by detecting the equality of pairs within the
+current buffer. (This feature is not supported for multibyte pairs)
 
 
                                                 *g:AutoPairsShortcutBackInsert*

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -103,7 +103,7 @@ Support ```, ''' and """: >
         output:
             '''|'''
 
-Auto detect when to close by checking the equality of pairs within the buffer: >
+Auto detect how to close/delete pairs by checking the equality of pairs: >
         input:
             const user = getUser|id)
 

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -115,6 +115,16 @@ Auto detect when to close by checking the equality of pairs within the buffer: >
         ---
 
         input:
+            ((|)
+
+        (press <BS> at |)
+
+        output:
+            (|)
+
+        ---
+
+        input:
             |]]
 
         (press [ at |)

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -291,9 +291,8 @@ Jump to the next closed pair.
 
 Default: 1
 
-Detects when to close a pair and how to delete an existing pair by detecting the
-equality of pairs within the current buffer. (This feature is not supported for
-multibyte pairs)
+Detects when to close/delete pairs by detecting the equality of pairs within the
+current buffer. (This feature is not supported for multibyte pairs)
 
 
                                                 *g:AutoPairsShortcutBackInsert*

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -281,8 +281,9 @@ Jump to the next closed pair.
 
 Default: 1
 
-Detects when to close a pair by detecting the equality of pairs within the
-current buffer. (This feature is not supported for multibyte pairs)
+Detects when to close a pair and how to delete an existing pair by detecting the
+equality of pairs within the current buffer. (This feature is not supported for
+multibyte pairs)
 
 
                                                 *g:AutoPairsShortcutBackInsert*

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -1,11 +1,11 @@
 " Insert or delete brackets, parens, quotes in pairs.
-" Maintainer:	JiangMiao <jiangfriend@gmail.com>
-" Contributor: camthompson
+" Maintainer:   JiangMiao <jiangfriend@gmail.com>
+" Contributors: camthompson, kkoomen
 " Last Change:  2019-02-02
-" Version: 2.0.0
-" Homepage: http://www.vim.org/scripts/script.php?script_id=3599
-" Repository: https://github.com/jiangmiao/auto-pairs
-" License: MIT
+" Version:      2.0.0
+" Homepage:     http://www.vim.org/scripts/script.php?script_id=3599
+" Repository:   https://github.com/jiangmiao/auto-pairs
+" License:      MIT
 
 if exists('g:AutoPairsLoaded') || &cp
   finish

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -342,6 +342,11 @@ func! AutoPairsDelete()
           return "\<BS>"
         end
       end
+      if strlen(open) == 1 && g:AutoPairsEqualPairDetection == 1
+        if s:count(open) !=# s:count(close)
+          return s:backspace(b)
+        endif
+      endif
       return s:backspace(b).s:delete(a)
     end
   endfor

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -233,10 +233,10 @@ func! AutoPairsInsert(key)
     let m = matchstr(afterline, '^\v\s*\zs\V'.close)
     if len(ms) > 0
       " process the open pair
-      
+
       " remove inserted pair
-      " eg: if the pairs include < > and  <!-- --> 
-      " when <!-- is detected the inserted pair < > should be clean up 
+      " eg: if the pairs include < > and  <!-- -->
+      " when <!-- is detected the inserted pair < > should be clean up
       let target = ms[1]
       let openPair = ms[2]
       if len(openPair) == 1 && m == openPair
@@ -523,7 +523,7 @@ func! AutoPairsInit()
       let opt['multiline'] = 0
     end
     let m = matchlist(close, '\v(.*)//(.*)$')
-    if len(m) > 0 
+    if len(m) > 0
       if m[2] =~ 'n'
         let opt['mapclose'] = 0
       end


### PR DESCRIPTION
Hi,

I've been using this plugin for several years and I tried to find a plugin that feels natural and logic when coding and from all the auto-pairing packages I have tested in the past years, this package is still the best package I could find.

<hr />

Until this day I haven't find a single package that does more than this package, but there is 1 thing that still no package is implementing: _equal pair detection_. 

Files _always_ have an equal amount of pairs. If not, there will be a parsing error and thus we are able to built things based on that.

This pull request adds support for the following scenarios (scroll further for demo):
```
input:
    const user = getUser|id)

(press ( at |)

output:
    const user = getUser(id)

---

input:
    ((|)

(press <BS> at |)

output:
    (|)

---

input:
    |]]

(press [ at |)

output:
    [|]]

(press [ at | again)

output:
    [[|]]

(press [ at | again)

output:
    [[[|]]]
```

I have only enabled this for single-byte pairs, because this will conflict for multibyte pairs.

**Working demo**
![equal-pair-detection-demo](https://user-images.githubusercontent.com/10693490/52914943-4db6fb00-32ce-11e9-8dc8-c53113a3322f.gif)


**What is does**
It checks whether the amount of _openers_ is equal to the amount of _closers_ in the current buffer. 

When opening a pair: it will refuse to close until the amount of openers/closers are equal again.

When deleting a pair: it will refuse to delete its corresponding closing part until the amount of openers/closers are equal again.

I made this a configurable option because there are always people who prefer to disable this. I did set this option to be _enabled_ by default, because I personally think this is a natural and logical way of detecting how pairs should be auto-closed or deleted.

**Additional features**
Another thing that a user is able to check with this feature is to instantly detect whether the buffer is correct in parenthesis/brackets/quotes. If you type `(` and you do not get a closing pair, then you know there is a parsing error.

<hr />

I also did push some styling fixes (converting remaining tabs -> spaces) and removing trailing white-space. This was automatically detected and fixed by my editor which is also nice for the codebase. I also fixed a small typo `" delete charactor` -> `" delete character`.

I did provide full documentation where needed. 

I hope this PR is according to the guidelines and coding standards you expect it to be and I hope this to be merged soon!

Thanks in advance.