### PR TITLE
[EXTRA_AUTO_PAIRS] Add support for extra auto pairs rather than over-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ Options
 
         Default: {'(':')', '[':']', '{':'}',"'":"'",'"':'"', "`":"`", '```':'```', '"""':'"""', "'''":"'''"}
 
+*   g:ExtraAutoPairs
+
+        Append to pristine dictionary of pairs rather than overwriting the it.
+        let g:ExtraAutoPairs = {'<':'>'}
+
 *   b:AutoPairs
 
         Default: g:AutoPairs

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -16,6 +16,13 @@ if !exists('g:AutoPairs')
   let g:AutoPairs = {'(':')', '[':']', '{':'}',"'":"'",'"':'"', '```':'```', '"""':'"""', "'''":"'''", "`":"`"}
 end
 
+" Extend default dictionary with extra pair dictionary
+" This feature is useful when user doesn't want to disturb the pristine AutoPairs
+" dictionary.
+if exists('g:ExtraAutoPairs')
+  call extend(g:AutoPairs, g:ExtraAutoPairs)
+end
+
 " default pairs base on filetype
 func! AutoPairsDefaultPairs()
   if exists('b:autopairs_defaultpairs')


### PR DESCRIPTION
…writing pristine pairs

Please note there is already support for doing this as follows,

  Existing support for adding new pairs
      let g:AutoPairs['<']='>'

  But, for adding numerous pairs it becomes tedious and repeatative. e.g.
      let g:AutoPairs['<']='>'
      let g:AutoPairs['"']='"'
      let g:AutoPairs['&']='&'
      let g:AutoPairs['@']='@'

  Instead of this current change enables user do following,
      let g:ExtraAutoPairs = {'<':'>', '"':'"', '&':'&', '@':'@'}

Signed-off-by: Rohan Vasant Ghige <rghige@cadence.com>