### PR TITLE
Fix AutoPairsJump for custom pairs

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -365,7 +365,7 @@ func! AutoPairsFastWrap()
 endf
 
 func! AutoPairsJump()
-  call search('["\]'')}]','W')
+  call search('[' . escape(join(values(b:AutoPairs), ''), "']") . ']', 'W')
 endf
 
 func! AutoPairsMoveCharacter(key)


### PR DESCRIPTION
By default AutoPairsJump function is hardcoded for default pairs only,
so it doesn't work for custom pairs and misses '`'
(which is in default AutoPairs).

This commit modifies AutoPairsJump function to properly work with custom
defined pairs by using b:AutoPairs variable values, so that the function
will attempt to search for any closing pair that is configured.