### PR TITLE
Paramterise AutoPairsFastWrap() to allow for custom movements

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -334,7 +334,7 @@ endf
 
 
 " Fast wrap the word in brackets
-func! AutoPairsFastWrap()
+func! AutoPairsFastWrap(movement)
   let c = @"
   normal! x
   let [before, after, ig] = s:getline()
@@ -354,7 +354,7 @@ func! AutoPairsFastWrap()
       end
     endfor
     if after[1:1] =~ '\v\w'
-      normal! e
+      execute "normal! ".a:movement
       normal! p
     else
       normal! p
@@ -559,7 +559,7 @@ func! AutoPairsInit()
   end
 
   if g:AutoPairsShortcutFastWrap != ''
-    execute 'inoremap <buffer> <silent> '.g:AutoPairsShortcutFastWrap.' <C-R>=AutoPairsFastWrap()<CR>'
+    execute 'inoremap <buffer> <silent> '.g:AutoPairsShortcutFastWrap.' <C-R>=AutoPairsFastWrap("e")<CR>'
   end
 
   if g:AutoPairsShortcutBackInsert != ''


### PR DESCRIPTION
By defining a movement parameter for AutoPairsFastWrap, we allow the user
to define addition fast-wrap style mappings, for example:

```
inoremap <buffer> <silent> <M-E> <C-R>=AutoPairsFastWrap("E")<CR>
inoremap <buffer> <silent> <M-$> <C-R>=AutoPairsFastWrap("$")<CR>
```

Whilst it might, in the future, seem appropriate/sensible/whatever to
add these as default mapping to auto-pairs, this change allows
experimentation in the short term.