### PR TITLE
(see #274) fix AutoPairsFastWrap: remove wrong `\` inside `[]`

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -21,9 +21,12 @@ func! AutoPairsDefaultPairs()
   if exists('b:autopairs_defaultpairs')
     return b:autopairs_defaultpairs
   end
+  " Added a more complex regex to capture in-line VimL comments
+  let no_quotes = '(\\\"|[^"])*'
+  let com_inl = '|^("'.no_quotes.'"*|[^"])* \zs"\ze'.no_quotes.'$'
   let r = copy(g:AutoPairs)
   let allPairs = {
-        \ 'vim': {'\v^\s*\zs"': ''},
+        \ 'vim': {'\v^\s*\zs"'.com_inl: ''},
         \ 'rust': {'\w\zs<': '>', '&\zs''': ''},
         \ 'php': {'<?': '?>//k]', '<?php': '?>//k]'}
         \ }
@@ -221,7 +224,7 @@ func! AutoPairsInsert(key)
       " when <!-- is detected the inserted pair < > should be clean up 
       let target = ms[1]
       let openPair = ms[2]
-      if len(openPair) == 1 && m == openPair
+      if (len(openPair) == 1 && m == openPair) || (close == '')
         break
       end
       let bs = ''
@@ -289,7 +292,6 @@ func! AutoPairsInsert(key)
     end
   endfor
 
-
   " Fly Mode, and the key is closed-pairs, search closed-pair and jump
   if g:AutoPairsFlyMode &&  a:key =~ '\v[\}\]\)]'
     if search(a:key, 'We')
@@ -307,8 +309,9 @@ func! AutoPairsDelete()
 
   let [before, after, ig] = s:getline()
   for [open, close, opt] in b:AutoPairsList
+    let rest_of_line = opt['multiline'] ? after : ig
     let b = matchstr(before, '\V'.open.'\v\s?$')
-    let a = matchstr(after, '^\v\s*\V'.close)
+    let a = matchstr(rest_of_line, '^\v\s*\V'.close)
     if b != '' && a != ''
       if b[-1:-1] == ' '
         if a[0] == ' '
@@ -495,7 +498,7 @@ func! AutoPairsInit()
     let c = close[0]
     let opt = {'mapclose': 1, 'multiline':1}
     let opt['key'] = c
-    if o == c
+    if o == c || len(c) == 0
       let opt['multiline'] = 0
     end
     let m = matchlist(close, '\v(.*)//(.*)$')

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -338,7 +338,7 @@ func! AutoPairsFastWrap()
   let c = @"
   normal! x
   let [before, after, ig] = s:getline()
-  if after[0] =~ '\v[\{\[\(\<]'
+  if after[0] =~ '\v[{[(<]'
     normal! %
     normal! p
   else


### PR DESCRIPTION
`'\v[\{\[\(\<]'` matches `'\'` because the collection pattern (`:help /[]`) matches *any single char* in the collection even though `\v` is used. Because of this, `AutoPairsFastWrap()` on texts like `{\bar{|}\asdf}` didn't work.

This patch removes such wrong `\`s.