### PR TITLE
Better parsing of comments in Vim Script

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -21,9 +21,12 @@ func! AutoPairsDefaultPairs()
   if exists('b:autopairs_defaultpairs')
     return b:autopairs_defaultpairs
   end
+  " Added a more complex regex to capture in-line VimL comments
+  let no_quotes = '(\\\"|[^"])*'
+  let com_inl = '|^("'.no_quotes.'"*|[^"])* \zs"\ze'.no_quotes.'$'
   let r = copy(g:AutoPairs)
   let allPairs = {
-        \ 'vim': {'\v^\s*\zs"': ''},
+        \ 'vim': {'\v^\s*\zs"'.com_inl: ''},
         \ 'rust': {'\w\zs<': '>', '&\zs''': ''},
         \ 'php': {'<?': '?>//k]', '<?php': '?>//k]'}
         \ }

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -212,11 +212,20 @@ func! AutoPairsInsert(key)
     return a:key
   end
 
+  echom "gline: ".string(s:getline())
   " check open pairs
   for [open, close, opt] in b:AutoPairsList
     let ms = s:matchend(before.a:key, open)
     let m = matchstr(afterline, '^\v\s*\zs\V'.close)
-    if len(ms) > 0
+    echom "beg?:  ".string(matchstr(before.a:key, '\V'.open.'\v$'))
+    echom "pair:  ".string([open, close, opt])
+    echom "ms:    ".string(ms)
+    echom "m:     ".string(m)
+    echom "key:   ".string(a:key)
+    " If the pair has no corresponding closing string, why bother
+    if close == ''
+        break
+    elseif len(ms) > 0
       " process the open pair
       
       " remove inserted pair
@@ -224,7 +233,7 @@ func! AutoPairsInsert(key)
       " when <!-- is detected the inserted pair < > should be clean up 
       let target = ms[1]
       let openPair = ms[2]
-      if len(openPair) == 1 && m == openPair
+      if (len(openPair) == 1 && m == openPair)
         break
       end
       let bs = ''
@@ -291,7 +300,6 @@ func! AutoPairsInsert(key)
       end
     end
   endfor
-
 
   " Fly Mode, and the key is closed-pairs, search closed-pair and jump
   if g:AutoPairsFlyMode &&  a:key =~ '\v[\}\]\)]'

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -312,6 +312,17 @@ func! AutoPairsDelete()
   for [open, close, opt] in b:AutoPairsList
     let b = matchstr(before, '\V'.open.'\v\s?$')
     let a = matchstr(after, '^\v\s*\V'.close)
+    echom 'getline yielded:'
+        echom "\tbefore:\t'" . before . "',"
+        echom "\tafter:\t'" . after . "',"
+        echom "\tig:\t'" . ig . "'"
+    echom 'pairs:'
+        echom "\topen:\t'" . open . "',"
+        echom "\tclose:\t'". close . "',"
+        echom "\topt:\t'" . string(opt) . "'"
+    echom 'results:'
+        echom "\tb:\t'" . b . "',"
+        echom "\ta:\t'" . a . "'"
     if b != '' && a != ''
       if b[-1:-1] == ' '
         if a[0] == ' '

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -313,18 +313,6 @@ func! AutoPairsDelete()
     let rest_of_line = opt['multiline'] ? after : ig
     let b = matchstr(before, '\V'.open.'\v\s?$')
     let a = matchstr(rest_of_line, '^\v\s*\V'.close)
-    echom 'getline yielded:'
-        echom "  before:       '" . before . "',"
-        echom "  after:        '" . after . "',"
-        echom "  ig:           '" . ig . "',"
-        echom "  rest_of_line: '" . after . "'" | echom ""
-    echom 'pairs:'
-        echom "  open:  '" . open . "',"
-        echom "  close: '" . close . "',"
-        echom "  opt:   '" . string(opt) . "'" | echom ""
-    echom 'results:'
-        echom "  b: '" . b . "',"
-        echom "  a: '" . a . "'"
     if b != '' && a != ''
       if b[-1:-1] == ' '
         if a[0] == ' '
@@ -511,7 +499,7 @@ func! AutoPairsInit()
     let c = close[0]
     let opt = {'mapclose': 1, 'multiline':1}
     let opt['key'] = c
-    if o == c
+    if o == c || len(c) == 0
       let opt['multiline'] = 0
     end
     let m = matchlist(close, '\v(.*)//(.*)$')

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -310,19 +310,21 @@ func! AutoPairsDelete()
 
   let [before, after, ig] = s:getline()
   for [open, close, opt] in b:AutoPairsList
+    let rest_of_line = opt['multiline'] ? after : ig
     let b = matchstr(before, '\V'.open.'\v\s?$')
-    let a = matchstr(after, '^\v\s*\V'.close)
+    let a = matchstr(rest_of_line, '^\v\s*\V'.close)
     echom 'getline yielded:'
-        echom "\tbefore:\t'" . before . "',"
-        echom "\tafter:\t'" . after . "',"
-        echom "\tig:\t'" . ig . "'"
+        echom "  before:       '" . before . "',"
+        echom "  after:        '" . after . "',"
+        echom "  ig:           '" . ig . "',"
+        echom "  rest_of_line: '" . after . "'" | echom ""
     echom 'pairs:'
-        echom "\topen:\t'" . open . "',"
-        echom "\tclose:\t'". close . "',"
-        echom "\topt:\t'" . string(opt) . "'"
+        echom "  open:  '" . open . "',"
+        echom "  close: '" . close . "',"
+        echom "  opt:   '" . string(opt) . "'" | echom ""
     echom 'results:'
-        echom "\tb:\t'" . b . "',"
-        echom "\ta:\t'" . a . "'"
+        echom "  b: '" . b . "',"
+        echom "  a: '" . a . "'"
     if b != '' && a != ''
       if b[-1:-1] == ' '
         if a[0] == ' '

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -212,20 +212,11 @@ func! AutoPairsInsert(key)
     return a:key
   end
 
-  echom "gline: ".string(s:getline())
   " check open pairs
   for [open, close, opt] in b:AutoPairsList
     let ms = s:matchend(before.a:key, open)
     let m = matchstr(afterline, '^\v\s*\zs\V'.close)
-    echom "beg?:  ".string(matchstr(before.a:key, '\V'.open.'\v$'))
-    echom "pair:  ".string([open, close, opt])
-    echom "ms:    ".string(ms)
-    echom "m:     ".string(m)
-    echom "key:   ".string(a:key)
-    " If the pair has no corresponding closing string, why bother
-    if close == ''
-        break
-    elseif len(ms) > 0
+    if len(ms) > 0
       " process the open pair
       
       " remove inserted pair
@@ -233,7 +224,7 @@ func! AutoPairsInsert(key)
       " when <!-- is detected the inserted pair < > should be clean up 
       let target = ms[1]
       let openPair = ms[2]
-      if (len(openPair) == 1 && m == openPair)
+      if (len(openPair) == 1 && m == openPair) || (close == '')
         break
       end
       let bs = ''


### PR DESCRIPTION
Hi @jiangmiao! 

I love auto-pairs, but there one thing that has annoyed me for quite a while. When I edit a vimscript file, and I try to put an in-line comment, meaning a comment after any instruction, auto-pairs detects it as a normal quote, and that leads to mayhem:

![here](https://user-images.githubusercontent.com/7331643/66681257-58007d80-ec40-11e9-86d9-aeb85e34b193.gif)

I think I found a way to fix this problem, and it is by changing the regex to detect quotes starting comments in `allPairs`.

Have a great day!

## Screenshots

### Old Regex
<img width="691" alt="Screen Shot 2019-10-11 at 13 01 11" src="https://user-images.githubusercontent.com/7331643/66670207-35ae3600-ec27-11e9-8374-2730ac6e091f.png">

### New Regex
<img width="691" alt="Screen Shot 2019-10-11 at 13 02 04" src="https://user-images.githubusercontent.com/7331643/66670256-54143180-ec27-11e9-887b-d89788f12db1.png">

## Appendix

Here is the test code, so you can play with it if necessary.

```vim
    " A. PLUGS IN PURGATORY
        " (To be deleted if they end up being disappointing.)
        Plug "kassio/neoterm"                   " Better Terminal integration
        Plug "kassio/neoterm"                   " Better Terminal integration
        let g:neoterm_default_mod = 'belowright' " in its proper place
        Plug "kassio/neoterm"
        Plug kassio/neoterm"dd
        Plug kassio/neoterm" dd
        Plug kassio/neoterm " dd
        Plug " kassio/neoterm " dd " Totaly

        ddddd "dddsdsd \"\"

" /^.*\zs".*$/  
"djdjdj"

let bol = '^\s*\zs"'
let no_q = '(\\\"|[^"])*'
let eol = '^("'.no_q.'"*|[^"])* \zs"\ze'.no_q.'$'
let re_old = '\v^\s*\zs"'
let re_new = '\v'.bol.'|'.eol

" Try the different regexes
execute '/'.re_new.'/'
echo '/'.re_new.'/'
```
