### PR TITLE
fix AutoPairsFastWrap: remove wrong `\` inside `[]`

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -338,7 +338,7 @@ func! AutoPairsFastWrap()
   let c = @"
   normal! x
   let [before, after, ig] = s:getline()
-  if after[0] =~ '\v[\{\[\(\<]'
+  if after[0] =~ '\v[{[(<]'
     normal! %
     normal! p
   else


### PR DESCRIPTION
`'\v[\{\[\(\<]'` matches `'\'` because the collection pattern (`:help /[]`) matches *any single char* in the collection even though `\v` is used. Because of this, `AutoPairsFastWrap()` on texts like `{\bar{|}\asdf}` didn't work.

This patch removes such wrong `\`s.