### PR TITLE
Fix plugin conflicts

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -671,3 +671,4 @@ imap <script> <Plug>AutoPairsReturn <SID>AutoPairsReturn
 
 
 au BufEnter * :call AutoPairsTryInit()
+call AutoPairsTryInit()


### PR DESCRIPTION
Some plug-ins (such as tagbar) will be loaded before auto pairs, and these plug-ins will create buffers on their own. In this way, auto pairs will not get the BuffEnter event and will not execute AutoPairsTryInit()
I added call AutoPairsTryInit() in the last line, which means trying to initialize the plug-in at the first time to solve the problem.