### PR TITLE
Fix spelling mistake

### DIFF
--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -9,7 +9,7 @@ CONTENTS                                                    *autopairs-contents*
 
     1. Installation ............................. |autopairs-installation|
     2. Features ..................................... |autopairs-features|
-    3. Fly Mode ..................................... |autopairs-fly-mode|
+    3. Fly Mode ..................................... |autopairs-flymode|
     4. Shortcuts ................................... |autopairs-shortcuts|
     5. Options ....................................... |autopairs-options|
     6. Troubleshooting ......................  |autopairs-troubleshooting|


### PR DESCRIPTION
Fixed spelling mistake in table of contents so that you can jump to the appropriate sections