### PR TITLE
Configuration option for fly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ If jumps in mistake, could use AutoPairsBackInsert(Default Key: `<M-b>`) to jump
 
 the most situation maybe want to insert single closed pair in the string, eg ")"
 
+If you want to use Fly Mode only for some brackets, e. g. for "}" and "]", but not for ")",
+set **let g:AutoPairsFlyBrackets** to a regex that matches the desired pairs, e. g. '\v[\}\]]'
+
 Fly Mode is DISABLED by default.
 
 add **let g:AutoPairsFlyMode = 1** .vimrc to turn it on
@@ -137,6 +140,7 @@ Default Options:
 
     let g:AutoPairsFlyMode = 0
     let g:AutoPairsShortcutBackInsert = '<M-b>'
+    let g:AutoPairsFlyBrackets = '\v[\}\]\)]'
 
 Shortcuts
 ---------

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -159,11 +159,16 @@ Fly Mode is DISABLED by default. To enable Fly Mode add following to your
 '.vimrc': >
 
     let g:AutoPairsFlyMode = 1
+    
+The brackets that will trigger Fly Mode can be set using
+
+    let g:AutoPairsFlyBrackets = '\v[\}\]]'
 
 Default Options: >
 
     let g:AutoPairsFlyMode = 0
     let g:AutoPairsShortcutBackInsert = '<M-b>'
+    let g:AutoPairsFlyBrackets = '\v[\}\]\)]'
 
 ==============================================================================
 4. Shortcuts                                             *autopairs-shortcuts*
@@ -313,6 +318,16 @@ Executes:
 Default: 0
 
 Set it to 1 to enable |autopairs-flymode|.
+
+
+                                                       *g:AutoPairsFlyBrackets*
+|g:AutoPairsFlyBrackets|                                                 string
+
+Default: '\v[\}\]\)]'
+
+Set it to a RegExp that should match Brackets which will trigger Fly Mode.
+By setting it to '\v[\}\]]' for example, only "}" and ")" will make the cursor
+jump to the closing bracket, and ) inserts a ).
 
 
                                                     *g:AutoPairsMultilineClose*

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -85,6 +85,12 @@ if !exists('g:AutoPairsFlyMode')
   let g:AutoPairsFlyMode = 0
 endif
 
+" Which closing brackets should trigger fly mode.
+" AutoPairsFlyBrackets is a regex of brackets to fly on
+if !exists('g:AutoPairsFlyBrackets')
+  let g:AutoPairsFlyBrackets = '\v[\}\]\)]'
+endif
+
 " When skipping the closed pair, look at the current and
 " next line as well.
 if !exists('g:AutoPairsMultilineClose')
@@ -291,7 +297,7 @@ func! AutoPairsInsert(key)
 
 
   " Fly Mode, and the key is closed-pairs, search closed-pair and jump
-  if g:AutoPairsFlyMode &&  a:key =~ '\v[\}\]\)]'
+  if g:AutoPairsFlyMode &&  a:key =~ g:AutoPairsFlyBrackets
     if search(a:key, 'We')
       return "\<Right>"
     endif


### PR DESCRIPTION
I'm using vim mainly for programming in Go.
In this language ) closes a function call and } closes a block.
So it very much makes sense for me to be able to jump to the end of the block using `}`. But I never want to jump to the next line when I simply want to close a function call.

That's why I added `g:AutoPairsFlyBrackets`. The check in the fly mode evaluation is replaced with this variable which can contain a regex of brackets to fly to.
If it's unset, it's set to the default of this repository.

I will add documentation soon.