### PR TITLE
Check that a key is present before attempting to remove it

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -186,7 +186,9 @@ func! AutoPairsDefine(pairs, ...)
   let r = AutoPairsDefaultPairs()
   if a:0 > 0
     for open in a:1
-      unlet r[open]
+      if has_key(r, open)
+        unlet r[open]
+      end
     endfor
   end
   for [open, close] in items(a:pairs)


### PR DESCRIPTION
When opening several files of the same filetype and AutoPairsDefine is used
with `au FileType … let b:AutoPairs = …`, AutoPairsDefine is called several
times but reuses the same dictionary set in the first call to AutoPairsDefine.

Let's assume we use

    au FileType verilog let b:AutoPairs = AutoPairsDefine({}, ['`'])

On the first buffer it removes the pair 

    "`": "`"

but the key no longer exists in `g:autopairs_defaultpairs` when the other buffers are loaded
resulting in ugly error messages.

This PR fixes that issue.