### PR TITLE
typo in AutoPairs.txt: Installation -> Introduction

### DIFF
--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -7,7 +7,7 @@ URL: https://github.com/jiangmiao/auto-pairs
 ==============================================================================
 CONTENTS                                                    *autopairs-contents*
 
-    1. Installation ............................. |autopairs-installation|
+    1. Introduction ............................. |autopairs-introduction|
     2. Features ..................................... |autopairs-features|
     3. Fly Mode ..................................... |autopairs-fly-mode|
     4. Shortcuts ................................... |autopairs-shortcuts|
@@ -15,7 +15,7 @@ CONTENTS                                                    *autopairs-contents*
     6. Troubleshooting ......................  |autopairs-troubleshooting|
 
 ==============================================================================
-1. Introduction                                         *autopairs-installation*
+1. Introduction                                         *autopairs-introduction*
 
 Copy `plugin/auto-pairs.vim` to `~/.vim/plugin`.
 


### PR DESCRIPTION
according to context, it showed be `Introduction`
